### PR TITLE
uwd2: allow uwd2 as a start-up app by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ directories = "5.0.1"
 pdb = "0.8.0"
 sysinfo = "0.30.5"
 ureq = "2.9.4"
+auto_launch = "0.5"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/auto_launch.rs
+++ b/src/auto_launch.rs
@@ -1,0 +1,12 @@
+use auto_launch::{AutoLaunch, WindowsEnableMode};
+
+fn enable_startup() -> Result<(), Box<dyn std::error::Error>> {
+    let app_name = "UWD2";
+    let exe_path = std::env::current_exe()?.to_string_lossy().into_owned();
+
+    // Specify current user (no admin required)
+    let auto = AutoLaunch::new(app_name, &exe_path, WindowsEnableMode::CurrentUser, &[]);
+
+    auto.enable()?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod explorer_modinfo;
 mod fetch_pdb;
 mod inject;
 mod parse_pdb;
+mod auto_launch;
 
 fn prog() -> String {
     // modified from https://stackoverflow.com/a/58113997/9044183


### PR DESCRIPTION
As some users have pointed out having to manually configure the app launch on start up, allow it natively. 

Tested on: Windows 11 Insider Preview Canary Build (28020.1362)